### PR TITLE
Apply Package Discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,12 @@
         "psr-4": {
             "Paytabscom\\Laravel_paytabs\\": "src/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Paytabscom\\Laravel_paytabs\\PaypageServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
Laravel will auto-discover the package instead of requiring users to add it manually.