### PR TITLE
CR: Fix missing BASE_URLS for both Morocco and Qatar

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -52,7 +52,7 @@ return [
    |--------------------------------------------------------------------------
    |
    | The region you registered in with PayTabs
-     you must pass value from this array ['ARE','EGY','SAU','OMN','JOR','GLOBAL']
+     you must pass value from this array ['ARE','EGY','SAU','OMN','JOR','IRQ','KWT','MAR','QAT','GLOBAL']
    |
    */
 

--- a/src/paytabs_core.php
+++ b/src/paytabs_core.php
@@ -1471,6 +1471,14 @@ class PaytabsApi
             'title' => 'Kuwait',
             'endpoint' => 'https://secure-kuwait.paytabs.com/'
         ],
+        'MAR' => [
+            'title' => 'Morocco',
+            'endpoint' => 'https://secure-morocco.paytabs.com/'
+        ],
+        'QAT' => [
+            'title' => 'Qatar',
+            'endpoint' => 'https://secure-doha.paytabs.com/'
+        ],
         'GLOBAL' => [
             'title' => 'Global',
             'endpoint' => 'https://secure-global.paytabs.com/'


### PR DESCRIPTION
This update introduces new instance base URL endpoints for the Morocco and Qatar instances supported by PayTabs. The corresponding ISO 3166-1 alpha‑3 country codes have been applied as follows:

- **Morocco**: MAR
_(Reference: [Source ISO 3166](https://www.iso.org/obp/ui#iso:code:3166:MA))_

- **Qatar**: QAT
_(Reference: [Source ISO 3166](https://www.iso.org/obp/ui/#iso:code:3166:QA))_

Both endpoints have been added to the core configuration file. Additionally, the config.php file has been updated to include and reflect these new values.

Regards,
PayTabs Tech Support Team